### PR TITLE
Fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ ORDER BY
 	title
 EOLATE
 
-	schedule = "*/5 * * * *"  # cron schedule for running the query 
+	schedule = "*/5 * * * *"  # cron schedule for running the query
 	rowformat = "object"      # HTTP json body is an array of objects
 	filebacked = true         # cache results in an encrypted temp file
 }
@@ -152,8 +152,7 @@ starting point and documentation.
 
 ellycache is a single static binary with no dependencies. You can deploy it into
 VMs or containers or even bundle it with your apps easily. It is written in
-pure Go, and can be built for any platform that [Go supports]
-(https://go.dev/wiki/MinimumRequirements).
+pure Go, and can be built for any platform that [Go supports](https://go.dev/wiki/MinimumRequirements).
 
 #### PostgreSQL connection pooling
 
@@ -174,7 +173,7 @@ file can decrypt them, and if that process crashes, then no one can.
 ### Support
 
 ellycache is an open-source project from [RapidLoop]
-(https://rapidloop.com) , the makers of [pgDash](https://pgdash.io]). It is
+(https://rapidloop.com) , the makers of [pgDash](https://pgdash.io). It is
 currently hosted at [GitHub](https://github.com/rapidloop/ellycache). Community
 support is available via [discussions](https://github.com/rapidloop/ellycache/discussions).
 Feel free to [raise issues you encounter](https://github.com/rapidloop/ellycache/issues) or


### PR DESCRIPTION
Couple small README tweaks I spotted while looking at the README

1. Extra trailing space on a config example
2. Fixes the go link (won't render link when split across newline)
![WezTerm 2024-11-25 14 11 45](https://github.com/user-attachments/assets/9f5f7cc5-d8e6-4730-868e-0ba4d8d781f2)
4. Fixes pgdash link (has trailing `]`) 
![CleanShot 2024-11-25 at 14 13 25@2x](https://github.com/user-attachments/assets/d67944b4-1039-478a-8186-9009cbb228e3)

Thanks!